### PR TITLE
Fix encoding detection unit test

### DIFF
--- a/c_to_plantuml/utils.py
+++ b/c_to_plantuml/utils.py
@@ -17,7 +17,7 @@ def get_acceptable_encodings() -> List[str]:
     return [
         "utf-8", "utf-8-sig", "utf-16", "utf-16le", "utf-16be",
         "windows-1252", "windows-1254", "cp1252", "cp1254",
-        "iso-8859-1", "latin-1"
+        "iso-8859-1", "latin-1", "ascii"  # Added 'ascii' as acceptable encoding
     ]
 
 


### PR DESCRIPTION
Add 'ascii' to acceptable encodings to correctly recognize ASCII files.

The `get_acceptable_encodings()` function previously did not include 'ascii', causing `is_acceptable_encoding` to return `False` for ASCII files, which led to a test failure in `test_detect_file_encoding_ascii`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f0a4bedb-d77c-415e-a0ad-b1a8dde7e18d) · [Cursor](https://cursor.com/background-agent?bcId=bc-f0a4bedb-d77c-415e-a0ad-b1a8dde7e18d)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)