### PR TITLE
Fix puml diagram header bug

### DIFF
--- a/c_to_plantuml/generator.py
+++ b/c_to_plantuml/generator.py
@@ -296,6 +296,9 @@ class PlantUMLGenerator:
                 )
         # Header-to-header relationships
         for include_relation in file_model.include_relations:
+            # Skip self-include
+            if include_relation.source_file == include_relation.included_file:
+                continue
             source_basename = Path(include_relation.source_file).stem
             included_basename = Path(include_relation.included_file).stem
             lines.append(

--- a/c_to_plantuml/generator.py
+++ b/c_to_plantuml/generator.py
@@ -150,7 +150,6 @@ class PlantUMLGenerator:
                 if file_basename == include_name or key == include_name:
                     included_file_model = model
                     break
-            
             # If not found in project_model.files, try to find it on the file system
             if not included_file_model:
                 included_file_path = self._find_included_file(
@@ -163,7 +162,9 @@ class PlantUMLGenerator:
                         if model.file_path == included_file_path:
                             included_file_model = model
                             break
-
+            # Skip self-include
+            if included_file_model and included_file_model.file_path == file_model.file_path:
+                continue
             if included_file_model:
                 header_basename = Path(included_file_model.file_path).stem
 
@@ -284,6 +285,9 @@ class PlantUMLGenerator:
                 if model.file_path == included_file_path:
                     included_file_model = model
                     break
+            # Skip self-include
+            if included_file_model and included_file_model.file_path == file_model.file_path:
+                continue
             if included_file_model:
                 header_basename = Path(included_file_path).stem
                 lines.append(

--- a/c_to_plantuml/generator.py
+++ b/c_to_plantuml/generator.py
@@ -296,7 +296,9 @@ class PlantUMLGenerator:
                 )
         # Header-to-header relationships
         for include_relation in file_model.include_relations:
-            # Skip self-include
+            # Only process relations relevant to this file and skip self-includes
+            if include_relation.source_file != file_model.file_path:
+                continue
             if include_relation.source_file == include_relation.included_file:
                 continue
             source_basename = Path(include_relation.source_file).stem

--- a/c_to_plantuml/generator.py
+++ b/c_to_plantuml/generator.py
@@ -296,11 +296,6 @@ class PlantUMLGenerator:
                 )
         # Header-to-header relationships
         for include_relation in file_model.include_relations:
-            # Only process relations relevant to this file and skip self-includes
-            if include_relation.source_file != file_model.file_path:
-                continue
-            if include_relation.source_file == include_relation.included_file:
-                continue
             source_basename = Path(include_relation.source_file).stem
             included_basename = Path(include_relation.included_file).stem
             lines.append(

--- a/run_example.bat
+++ b/run_example.bat
@@ -5,6 +5,6 @@ cd /d %SCRIPT_DIR%
 if exist output rmdir /s /q output
 mkdir output
 
-python main.py --config example/config.json
+python main.py --config example/config.json --verbose
 
 echo PlantUML diagrams generated in: %SCRIPT_DIR%output

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -384,27 +384,3 @@ class TestGenerator(unittest.TestCase):
         # Directory should be created
         self.assertTrue(os.path.exists(output_dir))
         self.assertTrue(os.path.exists(os.path.join(output_dir, "test.puml")))
-
-    def test_no_self_include(self):
-        """Test that a file including itself does not generate a self-include in the PlantUML diagram"""
-        file_model = FileModel(
-            file_path="self.h",
-            relative_path="self.h",
-            project_root="/test",
-            encoding_used="utf-8",
-            includes=["self.h"],
-            macros=[],
-            typedefs={},
-            globals=[],
-            functions=[],
-            structs={},
-            enums={},
-            unions={},
-            typedef_relations=[],
-            include_relations=[]
-        )
-        project_model = ProjectModel("test", "/test", {"self.h": file_model}, "2023-01-01")
-        generator = PlantUMLGenerator()
-        content = generator.generate_diagram(file_model, project_model)
-        # There should be no self-include relationship in the output
-        self.assertNotIn("SELF --> HEADER_SELF : <<include>>", content)

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -384,3 +384,27 @@ class TestGenerator(unittest.TestCase):
         # Directory should be created
         self.assertTrue(os.path.exists(output_dir))
         self.assertTrue(os.path.exists(os.path.join(output_dir, "test.puml")))
+
+    def test_no_self_include(self):
+        """Test that a file including itself does not generate a self-include in the PlantUML diagram"""
+        file_model = FileModel(
+            file_path="self.h",
+            relative_path="self.h",
+            project_root="/test",
+            encoding_used="utf-8",
+            includes=["self.h"],
+            macros=[],
+            typedefs={},
+            globals=[],
+            functions=[],
+            structs={},
+            enums={},
+            unions={},
+            typedef_relations=[],
+            include_relations=[]
+        )
+        project_model = ProjectModel("test", "/test", {"self.h": file_model}, "2023-01-01")
+        generator = PlantUMLGenerator()
+        content = generator.generate_diagram(file_model, project_model)
+        # There should be no self-include relationship in the output
+        self.assertNotIn("SELF --> HEADER_SELF : <<include>>", content)


### PR DESCRIPTION
Prevent header files from self-including in PlantUML diagrams and enable verbose output for example script.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-add1a223-6bbc-4436-a0b4-d5a3d33b14ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-add1a223-6bbc-4436-a0b4-d5a3d33b14ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)