### PR TITLE
Fix header self-include bug

### DIFF
--- a/c_to_plantuml/transformer.py
+++ b/c_to_plantuml/transformer.py
@@ -313,6 +313,10 @@ class Transformer:
             )
 
             if included_file_path and included_file_path in file_map:
+                # Prevent self-referencing include relations
+                if file_model.file_path == included_file_path:
+                    self.logger.debug(f"Skipping self-include relation for {file_model.file_path}")
+                    continue
                 # Create include relation
                 from .models import IncludeRelation
 


### PR DESCRIPTION
Fix bug where header files generated incorrect self-referencing include relations.

The previous logic incorrectly allowed a header file to be listed as including itself, leading to erroneous diagrams.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-d9e85d99-9b5e-4cbf-9c1b-a1a30915c787) · [Cursor](https://cursor.com/background-agent?bcId=bc-d9e85d99-9b5e-4cbf-9c1b-a1a30915c787)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)