### PR TITLE
Commit and push generated images

### DIFF
--- a/.github/workflows/convert-puml-to-jpeg.yml
+++ b/.github/workflows/convert-puml-to-jpeg.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         fetch-depth: 0
         
     - name: Configure Git
@@ -33,15 +33,19 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         
+    - name: Validate Personal Access Token
+      run: |
+        if [ -z "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
+          echo "❌ Error: PERSONAL_ACCESS_TOKEN secret is not configured"
+          echo "Please add a Personal Access Token with 'repo' scope as a repository secret"
+          exit 1
+        fi
+        echo "✅ Personal Access Token is configured"
+        
     - name: Setup Git credentials
       run: |
-        # Use Personal Access Token for pushing if available, otherwise use GITHUB_TOKEN
-        if [ -n "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
-          echo "Using Personal Access Token for authentication"
-          git remote set-url origin https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
-        else
-          echo "Using GITHUB_TOKEN for authentication"
-        fi
+        echo "Setting up Git credentials with Personal Access Token"
+        git remote set-url origin https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
         
     - name: Install PlantUML
       run: |
@@ -141,14 +145,9 @@ jobs:
           # Commit with detailed message
           git commit -F /tmp/commit_msg
           
-          # Push to the same branch
-          if [ -n "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
-            echo "Pushing with Personal Access Token..."
-            git push origin ${{ github.ref }}
-          else
-            echo "Pushing with GITHUB_TOKEN..."
-            git push origin ${{ github.ref }}
-          fi
+          # Push to the same branch using Personal Access Token
+          echo "Pushing with Personal Access Token..."
+          git push origin ${{ github.ref }}
           
           echo "✅ Successfully committed and pushed generated images"
         fi

--- a/.github/workflows/convert-puml-to-jpeg.yml
+++ b/.github/workflows/convert-puml-to-jpeg.yml
@@ -17,17 +17,31 @@ on:
 jobs:
   convert-puml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
         
     - name: Configure Git
       run: |
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        
+    - name: Setup Git credentials
+      run: |
+        # Use Personal Access Token for pushing if available, otherwise use GITHUB_TOKEN
+        if [ -n "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
+          echo "Using Personal Access Token for authentication"
+          git remote set-url origin https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
+        else
+          echo "Using GITHUB_TOKEN for authentication"
+        fi
         
     - name: Install PlantUML
       run: |
@@ -128,7 +142,13 @@ jobs:
           git commit -F /tmp/commit_msg
           
           # Push to the same branch
-          git push origin ${{ github.ref }}
+          if [ -n "${{ secrets.PERSONAL_ACCESS_TOKEN }}" ]; then
+            echo "Pushing with Personal Access Token..."
+            git push origin ${{ github.ref }}
+          else
+            echo "Pushing with GITHUB_TOKEN..."
+            git push origin ${{ github.ref }}
+          fi
           
           echo "✅ Successfully committed and pushed generated images"
         fi

--- a/README.md
+++ b/README.md
@@ -40,6 +40,43 @@ For development, install additional dependencies:
 pip install -r requirements-dev.txt
 ```
 
+## GitHub Actions Setup
+
+This project includes GitHub Actions workflows for automated PlantUML to JPEG conversion. To set up the workflows properly, you need to configure authentication.
+
+### Authentication Setup
+
+The workflow requires write permissions to commit generated images back to the repository. You have two options:
+
+#### Option 1: Use Personal Access Token (Recommended)
+
+1. Create a Personal Access Token (PAT) with `repo` scope:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+   - Generate a new token with `repo` permissions
+   - Copy the token
+
+2. Add the token as a repository secret:
+   - Go to your repository Settings → Secrets and variables → Actions
+   - Create a new secret named `PERSONAL_ACCESS_TOKEN`
+   - Paste your PAT as the value
+
+#### Option 2: Use Workflow Permissions (Alternative)
+
+The workflow is configured with explicit permissions that should work for most repositories. If you're still getting permission errors, ensure your repository settings allow workflow write access:
+
+1. Go to repository Settings → Actions → General
+2. Under "Workflow permissions", select "Read and write permissions"
+3. Check "Allow GitHub Actions to create and approve pull requests"
+
+### Running the Workflow
+
+1. Go to the Actions tab in your repository
+2. Select "Convert PlantUML to JPEG" workflow
+3. Click "Run workflow"
+4. Configure the input parameters:
+   - **Output folder**: Directory containing .puml files (default: `output`)
+   - **Commit changes**: Whether to commit generated images (default: `true`)
+
 ## Usage
 
 The tool provides a 3-step processing pipeline that can be executed individually or chained together:
@@ -414,6 +451,32 @@ The script will:
 - Convert all `.puml` files in the `output` directory to JPEG
 - Create both PNG (intermediate) and JPEG (final) files
 - Provide detailed progress information
+
+## Troubleshooting
+
+### GitHub Actions Permission Errors
+
+If you encounter permission errors like `Permission to fischerjooo/generator_project.git denied to github-actions[bot]`, follow these steps:
+
+1. **Check Repository Settings**:
+   - Go to repository Settings → Actions → General
+   - Ensure "Workflow permissions" is set to "Read and write permissions"
+   - Check "Allow GitHub Actions to create and approve pull requests"
+
+2. **Set up Personal Access Token** (if repository settings don't work):
+   - Create a PAT with `repo` scope
+   - Add it as a repository secret named `PERSONAL_ACCESS_TOKEN`
+   - The workflow will automatically use it for authentication
+
+3. **Verify Secret Configuration**:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Ensure `PERSONAL_ACCESS_TOKEN` is properly configured
+
+### Common Issues
+
+- **No images generated**: Check that `.puml` files exist in the specified output folder
+- **Conversion failures**: Ensure PlantUML syntax is valid in your `.puml` files
+- **Authentication errors**: Follow the authentication setup steps above
 
 ## Contributing
 


### PR DESCRIPTION
Update GitHub Actions workflow to use `PERSONAL_ACCESS_TOKEN` to resolve permission errors when pushing generated files.

The `github-actions[bot]` was denied permission to push changes using the default `GITHUB_TOKEN`. This PR configures the workflow to explicitly use a `PERSONAL_ACCESS_TOKEN` for all Git operations, ensuring write access. It also updates the README with comprehensive setup and troubleshooting instructions for this authentication method.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e7f23f5b-5af0-4bdc-ba99-84992e30380b) · [Cursor](https://cursor.com/background-agent?bcId=bc-e7f23f5b-5af0-4bdc-ba99-84992e30380b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)