### PR TITLE
Analyze and refine puml files

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -257,6 +257,7 @@ class "{basename}" as {UML_ID} <<source>> #LightBlue
 {
     -- Macros --
     - #define {macro_name}
+    - #define {macro_name}({parameters})
     -- Typedefs --
     - typedef {original_type} {typedef_name}  # Only primitive typedefs (relationship_type = "alias" and not struct/enum/union)
     -- Global Variables --
@@ -276,6 +277,7 @@ class "{header_name}" as {HEADER_UML_ID} <<header>> #LightGreen
 {
     -- Macros --
     + #define {macro_name}
+    + #define {macro_name}({parameters})
     -- Typedefs --
     + typedef {original_type} {typedef_name}  # Only primitive typedefs (relationship_type = "alias" and not struct/enum/union)
     -- Global Variables --
@@ -353,6 +355,11 @@ class "{original_type}" as {TYPE_UML_ID} <<type>> #LightGray
   - **Enum typedefs**: Show enum value names (e.g., `+ LOG_DEBUG`, `+ LOG_INFO`, `+ STATE_IDLE`, `+ STATE_RUNNING`)
   - **Union typedefs**: Show union field names and types (e.g., `+ int i`, `+ float f`)
   - **Primitive typedefs**: Show the original type name (e.g., `+ uint32_t`, `+ char*`)
+
+#### 5.2.5 Macro Display
+- **Simple defines**: Show only the macro name (e.g., `#define PI`, `#define VERSION`, `#define MAX_LABEL_LEN`)
+- **Function-like macros**: Show the macro name with parameters (e.g., `#define MIN(a, b)`, `#define MAX(a, b)`)
+- **Macro values are not displayed**: Only the macro name and parameters (if any) are shown, not the actual values or definitions
 
 ### 5.3 Include Depth Configuration
 

--- a/specification.md
+++ b/specification.md
@@ -293,13 +293,13 @@ class "{header_name}" as {HEADER_UML_ID} <<header>> #LightGreen
 ' Typedef classes for struct typedefs:
 class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 {
-    + {type} {field_name}
+    + {field_type} {field_name}
 }
 
 ' Typedef classes for enum typedefs:
 class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 {
-    + {enum_value_1} = {value_1}
+    + {enum_value_1}
     + {enum_value_2}
     + {enum_value_3}
 }
@@ -307,19 +307,19 @@ class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 ' Typedef classes for union typedefs:
 class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 {
-    + {type} {field_name}
+    + {field_type} {field_name}
 }
 
 ' Typedef classes for simple type typedefs:
 class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 {
-    + {original_type}
+    + {original_type_name}
 }
 
 ' Original type classes for struct/enum/union:
 class "{original_type}" as {TYPE_UML_ID} <<type>> #LightGray
 {
-    + {type} {field_name}
+    + {field_type} {field_name}
 }
 
 ' Relationships:
@@ -349,10 +349,10 @@ class "{original_type}" as {TYPE_UML_ID} <<type>> #LightGray
 #### 5.2.4 Typedef Content Display
 - **Source/Header files**: Show only primitive typedef declarations (e.g., `typedef int MyInt`, `typedef char* String`) - struct/enum/union typedefs are NOT shown in file/header classes
 - **Typedef classes**: Show the actual content:
-  - **Struct typedefs**: Show struct fields with their types (e.g., `+ int x`, `+ char* name`)
-  - **Enum typedefs**: Show enum values with their assignments (e.g., `+ LOG_DEBUG = 0`, `+ LOG_INFO`, `+ STATE_IDLE = 0`, `+ STATE_RUNNING`)
-  - **Union typedefs**: Show union fields with their types (e.g., `+ int i`, `+ float f`)
-  - **Primitive typedefs**: Show the original type (e.g., `+ uint32_t`, `+ char*`)
+  - **Struct typedefs**: Show struct field names and types (e.g., `+ int x`, `+ char* name`)
+  - **Enum typedefs**: Show enum value names (e.g., `+ LOG_DEBUG`, `+ LOG_INFO`, `+ STATE_IDLE`, `+ STATE_RUNNING`)
+  - **Union typedefs**: Show union field names and types (e.g., `+ int i`, `+ float f`)
+  - **Primitive typedefs**: Show the original type name (e.g., `+ uint32_t`, `+ char*`)
 
 ### 5.3 Include Depth Configuration
 

--- a/specification.md
+++ b/specification.md
@@ -299,7 +299,9 @@ class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 ' Typedef classes for enum typedefs:
 class "{typedef_name}" as {TYPEDEF_UML_ID} <<typedef>> #LightYellow
 {
-    + {value}
+    + {enum_value_1} = {value_1}
+    + {enum_value_2}
+    + {enum_value_3}
 }
 
 ' Typedef classes for union typedefs:
@@ -348,9 +350,9 @@ class "{original_type}" as {TYPE_UML_ID} <<type>> #LightGray
 - **Source/Header files**: Show only primitive typedef declarations (e.g., `typedef int MyInt`, `typedef char* String`) - struct/enum/union typedefs are NOT shown in file/header classes
 - **Typedef classes**: Show the actual content:
   - **Struct typedefs**: Show struct fields with their types (e.g., `+ int x`, `+ char* name`)
-  - **Enum typedefs**: Show enum values (e.g., `+ RED`, `+ GREEN`, `+ BLUE`)
-  - **Union typedefs**: Show union fields with their types (e.g., `+ int data`, `+ char* str`)
-  - **Simple type typedefs**: Show the original type (e.g., `+ int`, `+ char*`)
+  - **Enum typedefs**: Show enum values with their assignments (e.g., `+ LOG_DEBUG = 0`, `+ LOG_INFO`, `+ STATE_IDLE = 0`, `+ STATE_RUNNING`)
+  - **Union typedefs**: Show union fields with their types (e.g., `+ int i`, `+ float f`)
+  - **Primitive typedefs**: Show the original type (e.g., `+ uint32_t`, `+ char*`)
 
 ### 5.3 Include Depth Configuration
 


### PR DESCRIPTION
Update specification to clarify PlantUML output for macros and typedefs.

This PR refines the `specification.md` to:
- Specify that simple macros only show their name, and function-like macros show `name(parameters)`. Macro values are explicitly excluded.
- Update enum typedef display to show only enum value names, without assignments.
- Generalize the display rules for other typedef types (struct, union, primitive) and update PlantUML templates accordingly.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1883223f-25d8-4af9-b790-a3bef95a69a9) · [Cursor](https://cursor.com/background-agent?bcId=bc-1883223f-25d8-4af9-b790-a3bef95a69a9)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)