### PR TITLE
Fix bug from github issue 88

### DIFF
--- a/c_to_plantuml/main.py
+++ b/c_to_plantuml/main.py
@@ -139,30 +139,30 @@ Usage:
             logging.error(f"Error during transformation: {e}")
             return 1
 
-            # Generate command
-        if args.command == "generate":
-            try:
-                generator = Generator()
-                # Prefer transformed model, else fallback to model.json
-                if os.path.exists(transformed_model_file):
-                    model_to_use = transformed_model_file
-                elif os.path.exists(model_file):
-                    model_to_use = model_file
-                else:
-                    logging.error("No model file found for generation.")
-                    return 1
-                generator.generate(
-                    model_file=model_to_use,
-                    output_dir=output_folder,
-                    include_depth=getattr(config, "include_depth", 1),
-                )
-                logging.info(
-                    f"PlantUML generation complete! Output in: {output_folder}"
-                )
-                return 0
-            except Exception as e:
-                logging.error(f"Error generating PlantUML: {e}")
+    # Generate command
+    if args.command == "generate":
+        try:
+            generator = Generator()
+            # Prefer transformed model, else fallback to model.json
+            if os.path.exists(transformed_model_file):
+                model_to_use = transformed_model_file
+            elif os.path.exists(model_file):
+                model_to_use = model_file
+            else:
+                logging.error("No model file found for generation.")
                 return 1
+            generator.generate(
+                model_file=model_to_use,
+                output_dir=output_folder,
+                include_depth=getattr(config, "include_depth", 1),
+            )
+            logging.info(
+                f"PlantUML generation complete! Output in: {output_folder}"
+            )
+            return 0
+        except Exception as e:
+            logging.error(f"Error generating PlantUML: {e}")
+            return 1
 
     # Default: full workflow
     try:

--- a/tests/feature/test_cli_feature.py
+++ b/tests/feature/test_cli_feature.py
@@ -88,3 +88,12 @@ class TestCLIFeature(BaseFeatureTest):
         self.assertEqual(result.returncode, 0)
         puml_files = list(Path(self.output_dir).glob("*.puml"))
         self.assertGreaterEqual(len(puml_files), 1)
+
+    def test_generate_command_isolation(self):
+        """Test that generate command works when called independently without model files"""
+        # This test would have caught the CLI indentation bug
+        # It tests the generate command in isolation without any pre-existing model files
+        result = self.run_cli(["--config", self.config_path, "generate"])
+        # Should fail gracefully with proper error message when no model files exist
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("No model file found for generation", result.stdout)

--- a/tests/feature/test_cli_modes.py
+++ b/tests/feature/test_cli_modes.py
@@ -105,3 +105,12 @@ class TestCLIModes(BaseFeatureTest):
         self.assertTrue(os.path.exists(transformed_path))
         puml_files = list(Path(self.output_dir).glob("*.puml"))
         self.assertGreaterEqual(len(puml_files), 1)
+
+    def test_generate_mode_isolation(self):
+        """Test that generate mode works when called independently without model files"""
+        # This test would have caught the CLI indentation bug
+        # It tests the generate command in isolation without any pre-existing model files
+        result = self.run_cli(["--config", self.config_path, "generate"])
+        # Should fail gracefully with proper error message when no model files exist
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("No model file found for generation", result.stdout)


### PR DESCRIPTION
Fix indentation bug in `main.py` to enable independent `generate` command execution and add isolated tests to prevent recurrence.

The `generate` command block in `c_to_plantuml/main.py` was incorrectly indented, placing it inside the `transform` command's conditional block. This prevented the `generate` command from executing independently when called directly. Existing tests did not detect this because they always ran `generate` after `parse` or `transform` had already created necessary model files, causing the program to fall back to the full workflow and pass the tests. New tests have been added to specifically verify the isolated behavior of the `generate` command.

---

[Open in Web](https://www.cursor.com/agents?id=bc-93fa12ad-c799-4541-a5cd-c4d7e7696635) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-93fa12ad-c799-4541-a5cd-c4d7e7696635)