### PR TITLE
Fix test coverage workflow error

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -232,19 +232,24 @@ jobs:
         else
           # Create commit with timestamp
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          COMMIT_SHA="${{ github.sha }}"
+          PYTHON_VERSION="${{ matrix.python-version }}"
+          WORKFLOW_NAME="${{ github.workflow }}"
+          RUN_NUMBER="${{ github.run_number }}"
+          EVENT_NAME="${{ github.event_name }}"
           
           # Create detailed commit message
-          cat > /tmp/commit_msg << EOF
-📊 Update test coverage reports
-
-Generated: $TIMESTAMP
-Commit: ${{ github.sha }}
-Python: ${{ matrix.python-version }}
-Workflow: ${{ github.workflow }} #${{ github.run_number }}
-Trigger: ${{ github.event_name }}
-
-Generated Reports:
-EOF
+          {
+            echo "Update test coverage reports"
+            echo ""
+            echo "Generated: $TIMESTAMP"
+            echo "Commit: $COMMIT_SHA"
+            echo "Python: $PYTHON_VERSION"
+            echo "Workflow: $WORKFLOW_NAME #$RUN_NUMBER"
+            echo "Trigger: $EVENT_NAME"
+            echo ""
+            echo "Generated Reports:"
+          } > /tmp/commit_msg
           
           # Add list of generated files
           find tests/reports -type f -name "*" | sort | sed 's/^/- /' >> /tmp/commit_msg
@@ -258,7 +263,7 @@ EOF
           git commit -F /tmp/commit_msg
           
           # Push changes
-          git push origin ${{ github.ref }}
+          git push origin "${{ github.ref }}"
           echo "✅ Coverage reports committed and pushed"
         fi
         


### PR DESCRIPTION
Refactor GitHub Actions workflow commit message generation to fix YAML parsing errors.

The original heredoc block was causing YAML parsing errors due to GitHub Actions expressions being misinterpreted as YAML syntax. This fix replaces the heredoc with `echo` statements, pre-assigns GitHub Actions variables to shell variables, removes a problematic emoji, and properly quotes the `git push` command.

---

[Open in Web](https://www.cursor.com/agents?id=bc-06d4e185-d021-41d2-a55e-c81330f5f1d3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-06d4e185-d021-41d2-a55e-c81330f5f1d3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)