### PR TITLE
Update test coverage workflow triggers

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,9 +1,7 @@
 name: Test Suite with Coverage Reports
 
 on:
-  # Automatic triggers
-  push:
-    branches: [ main, master ]
+  # Automatic triggers - only on closed and merged pull requests
   pull_request:
     branches: [ main, master ]
     types: [closed]  # Trigger when PR is closed (merged)


### PR DESCRIPTION
Remove push trigger from `test-coverage.yml` workflow to only run on user trigger or on closed and merged pull requests.

---

[Open in Web](https://www.cursor.com/agents?id=bc-583c3033-a188-4930-910a-9c9d0dff3770) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-583c3033-a188-4930-910a-9c9d0dff3770)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)