### PR TITLE
Fix readme coverage report link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python tool for converting C/C++ source code to PlantUML diagrams. Analyzes C/
 
 - [📊 Combined Coverage Report](https://fischerjooo.github.io/generator_project/tests/reports/coverage/index.html) - Comprehensive coverage report with summary and detailed per-file analysis
 - [📄 Coverage Summary](https://fischerjooo.github.io/generator_project/tests/reports/coverage/coverage_summary.txt) - Text-based coverage summary
-- [📈 Standard HTML Coverage](https://fischerjooo.github.io/generator_project/tests/reports/coverage/htmlcov/index.html) - Traditional HTML coverage report
+- [📈 Standard HTML Coverage](https://fischerjooo.github.io/generator_project/tests/reports/coverage/index.html) - Traditional HTML coverage report
 - [📝 Test Summary](https://fischerjooo.github.io/generator_project/tests/reports/test-summary.txt) - Test execution summary and statistics
 
 ## Features


### PR DESCRIPTION
Fix incorrect link to standard HTML coverage report in `README.md`.

---

[Open in Web](https://cursor.com/agents?id=bc-1e6f316b-f800-46da-ac7a-6c2b0bfb4edc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1e6f316b-f800-46da-ac7a-6c2b0bfb4edc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)