### PR TITLE
Fix missing zero results in test summary

### DIFF
--- a/run_tests_with_coverage.sh
+++ b/run_tests_with_coverage.sh
@@ -198,23 +198,23 @@ fi
 
 print_success "Test summary generated at: tests/reports/test-summary.txt"
 
-# If coverage module is available and we ran with coverage, generate combined coverage report
-if [ "$HAS_COVERAGE" = true ] && grep -q "coverage report" tests/reports/test-output.log; then
-    print_header "Generating Combined Coverage Report"
-    
-    print_status "Generating comprehensive coverage reports (summary + detailed per-file)..."
-    if python3 generate_combined_coverage.py --output-dir tests/reports/coverage 2>&1 | tee tests/reports/coverage-generation.log; then
-        print_success "Combined coverage reports generated successfully!"
-        print_info "Reports include:"
-        print_info "  - Overall coverage summary"
-        print_info "  - Detailed per-file coverage with line-by-line analysis"
-        print_info "  - Standard HTML coverage report"
-        print_info "  - XML and JSON exports"
-    else
-        print_error "Failed to generate combined coverage reports"
-        print_info "Check tests/reports/coverage-generation.log for details"
+    # If coverage module is available and we ran with coverage, generate combined coverage report
+    if [ "$HAS_COVERAGE" = true ] && grep -q "coverage report" tests/reports/test-output.log; then
+        print_header "Generating Combined Coverage Report"
+        
+        print_status "Generating comprehensive coverage reports (summary + detailed per-file)..."
+        if python3 generate_combined_coverage.py --output-dir tests/reports/coverage --test-output-file tests/reports/test-output.log 2>&1 | tee tests/reports/coverage-generation.log; then
+            print_success "Combined coverage reports generated successfully!"
+            print_info "Reports include:"
+            print_info "  - Overall coverage summary"
+            print_info "  - Detailed per-file coverage with line-by-line analysis"
+            print_info "  - Standard HTML coverage report"
+            print_info "  - XML and JSON exports"
+        else
+            print_error "Failed to generate combined coverage reports"
+            print_info "Check tests/reports/coverage-generation.log for details"
+        fi
     fi
-fi
 
 # Display summary
 print_header "Test Execution Complete!"

--- a/tests/reports/test_summary.html
+++ b/tests/reports/test_summary.html
@@ -53,7 +53,7 @@
         }
         .success-rate {
             font-size: 48px;
-            color: #f44336;
+            color: #4caf50;
         }
         .status-badge {
             display: inline-block;
@@ -63,7 +63,7 @@
             font-size: 14px;
             text-transform: uppercase;
             color: white;
-            background: #f44336;
+            background: #4caf50;
         }
         .failed-tests {
             background: white;
@@ -134,26 +134,26 @@
         </div>
 
         <h1>Test Results Summary</h1>
-        <div class="timestamp">Generated: 2025-07-27 07:55:20</div>
+        <div class="timestamp">Generated: 2025-07-27 08:06:37</div>
 
         <div class="summary-card">
             <h2 style="margin-top: 0;">Test Execution Results</h2>
             <div style="margin-bottom: 20px;">
-                <span class="status-badge">UNKNOWN</span>
-                <span style="margin-left: 10px; color: #666;">Execution completed in 0.00 seconds</span>
+                <span class="status-badge">PASSED</span>
+                <span style="margin-left: 10px; color: #666;">Execution completed in 1.57 seconds</span>
             </div>
 
             <div class="stats-grid">
                 <div class="stat-card">
-                    <div class="stat-value success-rate">0.0%</div>
+                    <div class="stat-value success-rate">100.0%</div>
                     <div class="stat-label">Success Rate</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">0</div>
+                    <div class="stat-value">329</div>
                     <div class="stat-label">Total Tests</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value" style="color: #4caf50">0</div>
+                    <div class="stat-value" style="color: #4caf50">329</div>
                     <div class="stat-label">Passed</div>
                 </div>
                 <div class="stat-card">
@@ -172,13 +172,13 @@
 
             <div class="test-details">
                 <h3>Test Execution Details</h3>
-                <p><strong>Total Tests:</strong> 0</p>
-                <p><strong>Passed:</strong> 0 (0.0%)</p>
+                <p><strong>Total Tests:</strong> 329</p>
+                <p><strong>Passed:</strong> 329 (100.0%)</p>
                 <p><strong>Failed:</strong> 0 (0.0%)</p>
                 <p><strong>Skipped:</strong> 0 (0.0%)</p>
                 <p><strong>Errors:</strong> 0 (0.0%)</p>
-                <p><strong>Execution Time:</strong> 0.00 seconds</p>
-                <p><strong>Overall Status:</strong> UNKNOWN</p>
+                <p><strong>Execution Time:</strong> 1.57 seconds</p>
+                <p><strong>Overall Status:</strong> PASSED</p>
             </div>
 
 


### PR DESCRIPTION
Fix test summary HTML report showing 0 results by adding unittest output parsing and passing test logs to the report generator.

The `generate_combined_coverage.py` script was designed to parse pytest output, but the tests were being run using unittest, which has a different output format. This caused the HTML report to incorrectly display 0 tests. This PR updates the script to parse unittest output and modifies the workflow to pass the actual test run log to the report generator.

---

[Open in Web](https://cursor.com/agents?id=bc-00cb5ca8-32f4-4233-8f6f-52a0b869f92a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-00cb5ca8-32f4-4233-8f6f-52a0b869f92a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)