### PR TITLE
Investigate and fix duplicate puml2png action

### DIFF
--- a/.github/workflows/puml2png.yml
+++ b/.github/workflows/puml2png.yml
@@ -3,6 +3,13 @@ name: Convert PlantUML to PNG
 # This workflow converts PlantUML (.puml) files to PNG images and commits them to the repository.
 # It includes robust git conflict resolution to handle cases where the remote repository
 # has been updated while the workflow is running.
+#
+# NOTE: This workflow is triggered by:
+# 1. Manual workflow_dispatch (for manual runs)
+# 2. workflow_call from test-coverage.yml (for automated runs after PR merge)
+#
+# The push trigger was removed to prevent duplicate execution when PRs are merged,
+# as the test-coverage workflow already handles triggering this workflow when needed.
 
 on:
   workflow_dispatch:
@@ -27,16 +34,13 @@ on:
         description: 'Commit generated images to repository'
         required: false
         type: boolean
-  push:
-    paths:
-      - 'output/**/*.puml'
-      - 'picgen.sh'
-      - '.github/workflows/puml2png.yml'
-    branches: [ main, master ]
 
 jobs:
   convert-puml:
     runs-on: ubuntu-latest
+    concurrency:
+      group: "puml2png-conversion"
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -247,6 +247,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // This step triggers the puml2png workflow after successful test completion
+            // This is the primary trigger for PlantUML conversion after PR merges
             const { data: runs } = await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/PUML2PNG_DUPLICATE_FIX.md
+++ b/PUML2PNG_DUPLICATE_FIX.md
@@ -1,0 +1,112 @@
+# Fix for Duplicate puml2png Workflow Execution
+
+## Problem Description
+
+The `puml2png.yml` workflow was being executed **twice** when a pull request was merged due to conflicting trigger mechanisms:
+
+1. **Direct push trigger**: The workflow had a `push` trigger that activated when PlantUML files were pushed to main/master branches
+2. **Workflow call from test-coverage**: The `test-coverage.yml` workflow (triggered on PR merge) explicitly called `puml2png.yml` via `workflow_dispatch`
+
+## Root Cause
+
+When a PR was merged:
+1. The merge created a push to the main branch
+2. If PlantUML files were changed, this triggered `puml2png.yml` via the `push` trigger
+3. Simultaneously, `test-coverage.yml` ran (triggered by PR merge) and called `puml2png.yml` again via `workflow_dispatch`
+
+This resulted in duplicate workflow executions, wasting resources and potentially causing conflicts.
+
+## Solution Implemented
+
+### 1. Removed Redundant Push Trigger
+
+**File**: `.github/workflows/puml2png.yml`
+
+**Change**: Removed the `push` trigger section:
+```yaml
+# REMOVED:
+push:
+  paths:
+    - 'output/**/*.puml'
+    - 'picgen.sh'
+    - '.github/workflows/puml2png.yml'
+  branches: [ main, master ]
+```
+
+**Reasoning**: The `test-coverage.yml` workflow already handles triggering `puml2png.yml` when needed after PR merges, making the push trigger redundant.
+
+### 2. Added Concurrency Control
+
+**File**: `.github/workflows/puml2png.yml`
+
+**Change**: Added concurrency group to prevent multiple simultaneous executions:
+```yaml
+jobs:
+  convert-puml:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "puml2png-conversion"
+      cancel-in-progress: true
+```
+
+**Benefit**: If somehow multiple instances are triggered, only one will run at a time, with others being cancelled.
+
+### 3. Enhanced Documentation
+
+**File**: `.github/workflows/puml2png.yml`
+
+**Change**: Added clear documentation explaining the trigger mechanisms:
+```yaml
+# NOTE: This workflow is triggered by:
+# 1. Manual workflow_dispatch (for manual runs)
+# 2. workflow_call from test-coverage.yml (for automated runs after PR merge)
+#
+# The push trigger was removed to prevent duplicate execution when PRs are merged,
+# as the test-coverage workflow already handles triggering this workflow when needed.
+```
+
+## Current Trigger Flow
+
+After the fix, the workflow execution follows this pattern:
+
+1. **PR is merged** → Triggers `test-coverage.yml`
+2. **test-coverage.yml completes successfully** → Calls `puml2png.yml` via `workflow_dispatch`
+3. **puml2png.yml executes once** → Converts PlantUML files to PNG
+
+## Manual Execution
+
+The workflow can still be triggered manually via:
+- GitHub Actions UI (workflow_dispatch)
+- API calls to workflow_dispatch endpoint
+
+## Benefits of the Fix
+
+1. **Eliminates duplicate executions** - Only one instance runs per PR merge
+2. **Reduces resource usage** - No wasted CI/CD minutes
+3. **Prevents potential conflicts** - No race conditions between multiple instances
+4. **Maintains functionality** - All existing use cases are preserved
+5. **Improves reliability** - Concurrency control prevents overlapping executions
+
+## Testing the Fix
+
+To verify the fix works correctly:
+
+1. Create a PR with PlantUML file changes
+2. Merge the PR
+3. Check GitHub Actions - only one `puml2png.yml` execution should occur
+4. Verify that PNG files are generated correctly
+
+## Rollback Plan
+
+If issues arise, the push trigger can be restored by adding back the removed section:
+
+```yaml
+push:
+  paths:
+    - 'output/**/*.puml'
+    - 'picgen.sh'
+    - '.github/workflows/puml2png.yml'
+  branches: [ main, master ]
+```
+
+However, this would reintroduce the duplicate execution issue.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove redundant push trigger from `puml2png.yml` to prevent duplicate workflow executions on PR merge.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `puml2png.yml` workflow was being triggered twice when a pull request was merged: once by its `push` trigger and again by a `workflow_dispatch` call from `test-coverage.yml`. This change removes the redundant `push` trigger and adds concurrency control to ensure only a single, controlled execution.

---

[Open in Web](https://cursor.com/agents?id=bc-294af07a-d9f9-4430-aa41-f096fb3ba939) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-294af07a-d9f9-4430-aa41-f096fb3ba939) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)